### PR TITLE
add missing import to handlers/validateJwt.go file

### DIFF
--- a/handlers/validateJwt.go
+++ b/handlers/validateJwt.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 
 	"crypto"
 	"crypto/rsa"


### PR DESCRIPTION
# Changes
* Added the missing `errors` import to the `handlers/validateJwt.go` file.